### PR TITLE
Fix queryset count handling for empty responses

### DIFF
--- a/src/paperap/models/abstract/queryset.py
+++ b/src/paperap/models/abstract/queryset.py
@@ -325,7 +325,7 @@ class BaseQuerySet[_Model: BaseModel](Iterable[_Model]):
         for _ in _iter:
             break
 
-        if not self._last_response:
+        if self._last_response is None:
             # I don't think this should ever occur, but just in case.
             raise NotImplementedError("Requested iter, but no last response")
 
@@ -379,7 +379,7 @@ class BaseQuerySet[_Model: BaseModel](Iterable[_Model]):
         for _ in _iter:
             break
 
-        if not self._last_response:
+        if self._last_response is None:
             # I don't think this should ever occur, but just in case.
             raise NotImplementedError("Requested iter, but no last response")
 
@@ -659,7 +659,7 @@ class BaseQuerySet[_Model: BaseModel](Iterable[_Model]):
             This is an internal method that should not be called directly by users.
 
         """
-        if not (response := self.resource.request_raw(url=url, params=params)):
+        if (response := self.resource.request_raw(url=url, params=params)) is None:
             logger.debug("No response from request.")
             return
 


### PR DESCRIPTION
## Summary
- ensure BaseQuerySet.count and count_this_page only raise when last_response is actually missing
- allow _request_iter to process empty API responses instead of treating them as missing

## Testing
- pytest tests/integration/models/document/test_queryset.py::TestDocumentQuerysetBulkOperations::test_set_storage_path -q *(fails: requires Paperless configuration such as base_url)*

------
https://chatgpt.com/codex/tasks/task_e_68cb90b9f18c8322bb791bb8d62ed8f7